### PR TITLE
Fix missing "composer" option

### DIFF
--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -12,7 +12,9 @@ class InstallCommand extends JetstreamInstallCommand
      *
      * @var string
      */
-    protected $signature = 'billing-portal:install {stack=inertia} {--stripe=true}';
+    protected $signature = 'billing-portal:install {stack=inertia}
+                                                   {--stripe=true}
+                                                   {--composer=global : Absolute path to the Composer binary which should be used to install packages}';
 
     /**
      * The console command description.


### PR DESCRIPTION
## Overview

Error when install this package (follow it's README)

## Reproduct

```bash
$ composer require renoki-co/jetstream-cashier-billing-portal
$ php artisan billing-portal:install
```

## Expect

Install success

## Actuals

![image](https://user-images.githubusercontent.com/1757120/108181518-9e21f700-713a-11eb-9ba1-c3ee3938b536.png)

## How to fixed

Add option "composer" to install command
